### PR TITLE
fix: emulator blank screen on Windows (init race condition)

### DIFF
--- a/ide/frontend/index.html
+++ b/ide/frontend/index.html
@@ -29,45 +29,11 @@
         var vecx = new VecX();
         console.log('[JSVecX] Global vecx instance created:', vecx);
         
-        function initializeJSVecX() {
-            console.log('[JSVecX] Initializing JSVecX functionality...');
-            
-            // Test basic functionality
-            if (typeof vecx !== 'undefined' && vecx.constructor === VecX) {
-                console.log('[JSVecX] ✓ vecx instance is valid');
-                
-                // Test reset functionality
-                try {
-                    vecx.reset();
-                    console.log('[JSVecX] ✓ vecx.reset() successful');
-                } catch (e) {
-                    console.error('[JSVecX] ✗ vecx.reset() failed:', e);
-                }
-                
-                // Test BIOS loading
-                if (vecx.rom && vecx.rom.length > 0) {
-                    console.log('[JSVecX] ✓ ROM loaded, length:', vecx.rom.length);
-                } else {
-                    console.log('[JSVecX] ⚠ ROM not loaded');
-                }
-                
-                // Test main initialization
-                try {
-                    vecx.main();
-                    console.log('[JSVecX] ✓ vecx.main() called successfully');
-                } catch (e) {
-                    console.error('[JSVecX] ✗ vecx.main() failed:', e);
-                }
-                
-            } else {
-                console.error('[JSVecX] ✗ vecx instance is invalid');
-            }
-        }
-        
-        // Initialize JSVecX when DOM is ready
+        // NOTE: vecx.main() is NOT called here — EmulatorPanel owns display
+        // initialization after the canvas element exists in the DOM.
+        // Calling main() here would race with React rendering <canvas id="screen">.
         $(document).ready(function() {
-            console.log('[JSVecX] Document ready, initializing vecx...');
-            initializeJSVecX();
+            console.log('[JSVecX] Document ready — vecx instance created, waiting for EmulatorPanel to initialize display');
         });
         
         // ========== DEBUG SYSTEM SETUP ==========

--- a/ide/frontend/public/jsvecx_deploy/osint.js
+++ b/ide/frontend/public/jsvecx_deploy/osint.js
@@ -274,6 +274,11 @@ function osint()
         this.lPitch = this.bytes_per_pixel * this.screen_x;
         this.osint_defaults();
         this.canvas = document.getElementById('screen');
+        if( !this.canvas )
+        {
+            console.error('[osint] Canvas element #screen not found — display init deferred');
+            return;
+        }
         this.ctx = this.canvas.getContext('2d');
         this.imageData = this.ctx.getImageData(0, 0, this.screen_x, this.screen_y);
         this.data = this.imageData.data;

--- a/ide/frontend/src/components/panels/EmulatorPanel.tsx
+++ b/ide/frontend/src/components/panels/EmulatorPanel.tsx
@@ -413,15 +413,27 @@ export const EmulatorPanel: React.FC = () => {
       console.log(`[EmulatorPanel] Initializing JSVecX with canvas size: ${canvasSize.width}x${canvasSize.height} (visible: ${rect.width}x${rect.height})`);
       
       try {
+      // CRITICAL: Ensure osint display + CPU are initialized with the canvas element.
+      // index.html only creates the vecx instance — it does NOT call vecx.main() because
+      // the canvas doesn't exist yet at DOMContentLoaded time (React renders it later).
+      // We perform the equivalent of vecx.main() here, minus auto-start.
+      if (!vecx.osint?.ctx) {
+        console.log('[EmulatorPanel] Initializing osint display with canvas...');
+        vecx.osint.init(vecx);
+        console.log('[EmulatorPanel] ✓ osint.init() successful');
+      }
+      if (!vecx.e6809?.vecx) {
+        console.log('[EmulatorPanel] Initializing e6809 CPU...');
+        vecx.e6809.init(vecx);
+        console.log('[EmulatorPanel] ✓ e6809.init() successful');
+      }
+
       console.log('🔄 [EmulatorPanel] CALLING vecx.reset() - Reason: JSVecX initialization');
-      // console.log('📍 [EmulatorPanel] Reset stack trace:', new Error().stack); // Debug only
-      vecx.reset();
-      console.log('[EmulatorPanel] ✓ vecx.reset() successful');
+      vecx.vecx_reset();
+      vecx.osint.osint_clearscreen();
+      console.log('[EmulatorPanel] ✓ vecx reset successful');
         
-        // DO NOT auto-start - user controls when to start manually
-        // vecx.main() would start emulator immediately
-        // vecx.debugState = 'stopped'; // Don't set running yet
-        console.log('[EmulatorPanel] ✓ JSVecx initialized (stopped, ready for manual start)');
+      console.log('[EmulatorPanel] ✓ JSVecx initialized (stopped, ready for manual start)');
         
         jsVecxInitialized.current = true; // Mark as initialized
         
@@ -2299,35 +2311,34 @@ export const EmulatorPanel: React.FC = () => {
         }
         
         // CRITICAL: Verificar que JSVecX esté completamente inicializado antes de reset
-        // Si el panel del emulador no estaba visible, JSVecX puede no estar inicializado
+        // Check osint.ctx (display) and e6809.vecx (CPU) — NOT vecx.ram which always exists
         console.log('[EmulatorPanel] Checking JSVecX initialization...');
-        const isInitialized = vecx.ram && vecx.ram.length > 0;
+        const isDisplayInitialized = !!vecx.osint?.ctx;
+        const isCpuInitialized = !!vecx.e6809?.vecx;
         
-        if (!isInitialized) {
-          console.warn('[EmulatorPanel] JSVecX not initialized - running full initialization...');
-          // Inicializar JSVecX completamente (igual que cuando el panel es visible)
+        if (!isDisplayInitialized || !isCpuInitialized) {
+          console.warn('[EmulatorPanel] JSVecX not fully initialized - running initialization...');
           try {
-            // Fase 1: Reset inicial
-            vecx.reset();
+            if (!isDisplayInitialized) {
+              vecx.osint.init(vecx);
+              console.log('[EmulatorPanel] ✓ osint.init() successful');
+            }
+            if (!isCpuInitialized) {
+              vecx.e6809.init(vecx);
+              console.log('[EmulatorPanel] ✓ e6809.init() successful');
+            }
+            
+            vecx.vecx_reset();
+            vecx.osint.osint_clearscreen();
             console.log('[EmulatorPanel] ✓ JSVecX reset successful');
             
-            // Fase 2: Main initialization (necesario para setup completo)
-            vecx.main();
-            console.log('[EmulatorPanel] ✓ JSVecX main() successful');
-            
-            // CRITICAL: Set debugState to 'running' after initialization
-            vecx.debugState = 'running';
-            console.log('[EmulatorPanel] ✓ JSVecx debugState set to running (after main)');
-            
-            // Fase 3: CRITICAL - Inicializar joystick input state a valores neutros
-            // Sin esto, las variables de joystick contienen basura y causan movimiento fantasma
+            // Inicializar joystick input state a valores neutros
             vecx.leftHeld = false;
             vecx.rightHeld = false;
             vecx.upHeld = false;
             vecx.downHeld = false;
-            vecx.shadow_snd_regs14 = 0xFF; // PSG: 0xFF = all buttons released (active low)
-            vecx.write8(0xC80F, 0x00);     // Vec_Btn_State: 0x00 = all buttons released (active high)
-            // console.log('[EmulatorPanel] ✓ Joystick state initialized to neutral');
+            vecx.shadow_snd_regs14 = 0xFF;
+            vecx.write8(0xC80F, 0x00);
             
             // console.log('[EmulatorPanel] ✓ JSVecX fully initialized in background');
           } catch (e) {


### PR DESCRIPTION
Symptoms (on Windows) - Blank emulator in the IDE (sounds play fine).

Move osint/e6809 initialization from index.html to EmulatorPanel, ensuring the canvas element exists in the DOM before osint.init() calls document.getElementById('screen').

- Remove vecx.main() call from index.html DOMContentLoaded handler
- EmulatorPanel now owns display init after canvas is rendered
- Add null-guard in osint.init() for missing canvas element
- Fix bogus vecx.ram.length init check (always true) with proper osint.ctx and e6809.vecx checks

Fixes #1 (https://github.com/pacovidal/vectrex-studio/issues/1)
